### PR TITLE
Fix clone definition

### DIFF
--- a/src/org/martinklepsch/cc_set/impl.cljs
+++ b/src/org/martinklepsch/cc_set/impl.cljs
@@ -9,7 +9,7 @@
   (-meta [coll] meta)
 
   ICloneable
-  (-clone [_] (CustomComparatorSet. meta hash-map comparator))
+  (-clone [_] (CustomComparatorSet. meta data-map comparator))
 
   IIterable
   (-iterator [_] (HashSetIter. (-iterator data-map)))

--- a/test/org/martinklepsch/cc_set_test.cljc
+++ b/test/org/martinklepsch/cc_set_test.cljc
@@ -43,6 +43,11 @@
     (t/is (= (ccset/custom-comparator-set :k)
              (empty (ccset/custom-comparator-set :k {:k "a"}))))))
 
+(deftest cloning
+  (t/testing "clone ccset"
+    (t/is (= (ccset/custom-comparator-set :k {:k "a"})
+             (clone (ccset/custom-comparator-set :k {:k "a"}))))))
+
 (deftest adding-values
   (t/testing "conj value to empty ccset"
     (t/is (= (ccset/custom-comparator-set :k {:k "a"})


### PR DESCRIPTION
The definition for clone was using `hash-map` instead of `data-map`.
