### PR TITLE
Make ccsets equal to other sets only

### DIFF
--- a/src/org/martinklepsch/cc_set/impl.clj
+++ b/src/org/martinklepsch/cc_set/impl.clj
@@ -6,7 +6,7 @@
                    this
                    (CustomComparatorSet. (assoc data (comparator v) v) comparator)))
   (empty [this] (CustomComparatorSet. {} comparator))
-  (equiv [this o] (= (set (seq this)) (set (seq o))))
+  (equiv [this o] (= (set (seq this)) o))
   (seq [this] (vals data))
 
   clojure.lang.Counted

--- a/src/org/martinklepsch/cc_set/impl.cljs
+++ b/src/org/martinklepsch/cc_set/impl.cljs
@@ -23,7 +23,7 @@
   (-empty [coll] (CustomComparatorSet. meta {} comparator))
 
   IEquiv
-  (-equiv [coll o] (= (set (seq coll)) (set (seq o))))
+  (-equiv [coll o] (= (set (seq coll)) o))
 
   ISeqable
   (-seq [_] (vals data-map))

--- a/test/org/martinklepsch/cc_set_test.cljc
+++ b/test/org/martinklepsch/cc_set_test.cljc
@@ -21,6 +21,8 @@
            (ccset/custom-comparator-set :k {:k "a"})))
   (t/is (= (ccset/custom-comparator-set :k {:k "a"}) #{{:k "a"}}))
   (t/is (= #{{:k "a"}} (ccset/custom-comparator-set :k {:k "a"})))
+  (t/is (not= (ccset/custom-comparator-set :k) []))
+  (t/is (= (ccset/custom-comparator-set :k) #{}))
   (t/is (not= (ccset/custom-comparator-set :k {:k "a"})
               {"a" {:k "a"}})))
 


### PR DESCRIPTION
Motivation:

```
(= #{} []) #_=> false
```

This commit leads to the same outcome for ccsets.
